### PR TITLE
Add an optional max_length argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,15 @@ The encoded ID is configurable. The following can be changed:
 
 The actual length of the encoded string can be longer if the inputs cannot be represented in the minimum length.
 
+### `max_length`
+
+`max_length`: the maximum length of the encoded string. The default is 128 characters.
+
+The maximum length represents both the longest encoded string that will be generated and also a limit on
+the maximum input length that will be decoded. If the encoded string exceeds `max_length` then a
+`EncodedIdLengthError` will be raised. If the input exceeds `max_length` then a `InvalidInputError` will
+be raised. If `max_length` is set to `nil`, then no validation, even using the default will be performed.
+
 ### `alphabet`
 
 `alphabet`: the alphabet used in the encoded string. By default it uses a variation of the Crockford reduced character set (https://www.crockford.com/base32.html).

--- a/lib/encoded_id.rb
+++ b/lib/encoded_id.rb
@@ -12,5 +12,7 @@ module EncodedId
 
   class EncodedIdFormatError < ArgumentError; end
 
+  class EncodedIdLengthError < ArgumentError; end
+
   class InvalidInputError < ArgumentError; end
 end

--- a/sig/encoded_id.rbs
+++ b/sig/encoded_id.rbs
@@ -3,6 +3,7 @@ module EncodedId
 
   InvalidConfigurationError: ::StandardError
   EncodedIdFormatError: ::ArgumentError
+  EncodedIdLengthError: ::ArgumentError
   InvalidAlphabetError: ::ArgumentError
   InvalidInputError: ::ArgumentError
 
@@ -56,7 +57,7 @@ module EncodedId
   end
 
   class ReversibleId
-    def initialize: (salt: ::String, ?length: ::Integer, ?split_at: ::Integer, ?split_with: ::String, ?alphabet: Alphabet, ?hex_digit_encoding_group_size: ::Integer) -> void
+    def initialize: (salt: ::String, ?length: ::Integer, ?split_at: ::Integer, ?split_with: ::String, ?alphabet: Alphabet, ?hex_digit_encoding_group_size: ::Integer, ?max_length: ::Integer) -> void
 
     # Encode the input values into a hash
     def encode: (encodeableValue values) -> ::String
@@ -79,6 +80,7 @@ module EncodedId
     attr_reader salt: ::String
 
     attr_reader length: ::Integer
+    attr_reader max_length: ::Integer | nil
 
     attr_reader alphabet: Alphabet
 
@@ -90,6 +92,7 @@ module EncodedId
     def validate_alphabet: (Alphabet) -> Alphabet
     def validate_salt: (::String) -> ::String
     def validate_length: (::Integer) -> ::Integer
+    def validate_max_length: (::Integer | nil) -> (::Integer | nil)
     def validate_split_at: (::Integer | nil) -> (::Integer | nil)
     def validate_split_with: (::String, Alphabet) -> ::String
     def validate_hex_digit_encoding_group_size: (::Integer) -> ::Integer


### PR DESCRIPTION
The max_length allows for limits on the encoded id and will be defaulted to 128 characters.

In addition to the changes needed to support max_length in encoding and decoding, I had to add `max_length: nil` to a few of the tests in order to not get caught by the default max_length.