### PR TITLE
Add max_inputs_per_id as argument for ReversibleId#initialize

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,13 @@ the maximum input length that will be decoded. If the encoded string exceeds `ma
 `EncodedIdLengthError` will be raised. If the input exceeds `max_length` then a `InvalidInputError` will
 be raised. If `max_length` is set to `nil`, then no validation, even using the default will be performed.
 
+### `max_inputs_per_id`
+
+`max_inputs_per_id`: the maximum amount of IDs to be encoded together. The default is 32.
+
+This maximum amount is used to limit the length of array input passed to `encode` and `encode_hex` function.
+`InvalidInputError` wil be raised when array longer than `max_inputs_per_id` is provided.
+
 ### `alphabet`
 
 `alphabet`: the alphabet used in the encoded string. By default, it uses a variation of the Crockford reduced character set (https://www.crockford.com/base32.html).

--- a/README.md
+++ b/README.md
@@ -141,7 +141,9 @@ be raised. If `max_length` is set to `nil`, then no validation, even using the d
 
 `max_inputs_per_id`: the maximum amount of IDs to be encoded together. The default is 32.
 
-This maximum amount is used to limit the length of array input passed to `encode` and `encode_hex` function.
+This maximum amount is used to limit:
+- the length of array input passed to `encode`
+- the length of integer array encoded in hex string(s) passed to `encode_hex` function.
 `InvalidInputError` wil be raised when array longer than `max_inputs_per_id` is provided.
 
 ### `alphabet`

--- a/lib/encoded_id/reversible_id.rb
+++ b/lib/encoded_id/reversible_id.rb
@@ -21,18 +21,14 @@ module EncodedId
 
     # Encode the input values into a hash
     def encode(values)
-      inputs = prepare_input(values)
-      encoded_id = encoded_id_generator.encode(inputs)
-      encoded_id = humanize_length(encoded_id) unless split_at.nil?
-
-      raise EncodedIdLengthError if max_length_exceeded?(encoded_id)
-
-      encoded_id
+      validate_input_length(values)
+      encode_integer_array(values)
     end
 
     # Encode hex strings into a hash
     def encode_hex(hexs)
-      encode(hex_represention_encoder.hex_as_integers(hexs))
+      validate_input_length(hexs)
+      encode_integer_array(hex_represention_encoder.hex_as_integers(hexs))
     end
 
     # Decode the hash to original array
@@ -59,6 +55,16 @@ module EncodedId
       :split_with,
       :hex_represention_encoder,
       :max_length
+
+    def encode_integer_array(values)
+      inputs = prepare_input(values)
+      encoded_id = encoded_id_generator.encode(inputs)
+      encoded_id = humanize_length(encoded_id) unless split_at.nil?
+
+      raise EncodedIdLengthError if max_length_exceeded?(encoded_id)
+
+      encoded_id
+    end
 
     def validate_alphabet(alphabet)
       return alphabet if alphabet.is_a?(Alphabet)
@@ -101,11 +107,16 @@ module EncodedId
       value.is_a?(Integer) && value > 0
     end
 
+    def validate_input_length(values)
+      return unless values.is_a?(Array)
+      return unless values.length > @max_inputs_per_id
+
+      raise ::EncodedId::InvalidInputError, "%d IDs provided, maximum amount of IDs is %d" % [values.length, @max_inputs_per_id]
+    end
+
     def prepare_input(value)
       inputs = value.is_a?(Array) ? value.map(&:to_i) : [value.to_i]
       raise ::EncodedId::InvalidInputError, "Integer IDs to be encoded can only be positive" if inputs.any?(&:negative?)
-
-      raise ::EncodedId::InvalidInputError, "%d IDs provided, maximum amount of IDs is %d" % [inputs.length, @max_inputs_per_id] if inputs.length > @max_inputs_per_id
 
       inputs
     end

--- a/sig/encoded_id.rbs
+++ b/sig/encoded_id.rbs
@@ -59,7 +59,7 @@ module EncodedId
   end
 
   class ReversibleId
-    def initialize: (salt: ::String, ?length: ::Integer, ?split_at: ::Integer, ?split_with: ::String, ?alphabet: Alphabet, ?hex_digit_encoding_group_size: ::Integer, ?max_length: ::Integer) -> void
+    def initialize: (salt: ::String, ?length: ::Integer, ?split_at: ::Integer, ?split_with: ::String, ?alphabet: Alphabet, ?hex_digit_encoding_group_size: ::Integer, ?max_length: ::Integer, ?max_inputs_per_id: ::Integer) -> void
 
     # Encode the input values into a hash
     def encode: (encodeableValue values) -> ::String
@@ -95,6 +95,7 @@ module EncodedId
     def validate_salt: (::String) -> ::String
     def validate_length: (::Integer) -> ::Integer
     def validate_max_length: (::Integer | nil) -> (::Integer | nil)
+    def validate_max_input: (::Integer) -> ::Integer
     def validate_split_at: (::Integer | nil) -> (::Integer | nil)
     def validate_split_with: (::String, Alphabet) -> ::String
     def validate_hex_digit_encoding_group_size: (::Integer) -> ::Integer
@@ -108,7 +109,7 @@ module EncodedId
 
     def humanize_length: (::String hash) -> ::String
 
-    def convert_to_hash: (::String str) -> ::String
+    def convert_to_hash: (::String str, bool) -> ::String
 
     def map_equivalent_characters: (::String str) -> ::String
     def max_length_exceeded?: (::String str) -> bool

--- a/test/encoded_id/test_reversible_id.rb
+++ b/test/encoded_id/test_reversible_id.rb
@@ -420,7 +420,7 @@ class TestReversibleId < Minitest::Test
   end
 
   def test_it_raises_when_encode_hex_amount_of_id_provided_exceeds_max_inputs
-    id = "9a566b8b-8618-42ab-8db7-a5a0276401fd"
+    id = ["9a566b8b-8618-42ab-8db7-a5a0276401fd", "9a566b8b-8618-42ab-8db7-a5a0276401fd"]
     assert_raises ::EncodedId::InvalidInputError do
       ::EncodedId::ReversibleId.new(salt: salt, max_inputs_per_id: 1).encode_hex(id)
     end

--- a/test/encoded_id/test_reversible_id.rb
+++ b/test/encoded_id/test_reversible_id.rb
@@ -87,6 +87,18 @@ class TestReversibleId < Minitest::Test
     end
   end
 
+  def test_it_raises_with_invalid_inputs_length
+    assert_raises ::EncodedId::InvalidConfigurationError do
+      ::EncodedId::ReversibleId.new(salt: salt, max_inputs_per_id: 0)
+    end
+  end
+
+  def test_it_raises_with_invalid_inputs_length_type
+    assert_raises ::EncodedId::InvalidConfigurationError do
+      ::EncodedId::ReversibleId.new(salt: salt, max_inputs_per_id: "foo")
+    end
+  end
+
   def test_it_raises_with_invalid_alphabet
     assert_raises ::EncodedId::InvalidAlphabetError do
       ::EncodedId::ReversibleId.new(salt: salt, alphabet: 1234)
@@ -397,6 +409,20 @@ class TestReversibleId < Minitest::Test
     id = ["9a566b8b-8618-42ab-8db7-a5a0276401fd", "59f3905a-e704-4714-b42e-960c82b699fe", "9c0498f3-639d-41ed-87c3-715c61e14798"]
     assert_raises ::EncodedId::EncodedIdLengthError do
       ::EncodedId::ReversibleId.new(salt: salt, max_length: 8).encode_hex(id)
+    end
+  end
+
+  def test_it_raises_when_encode_amount_of_id_provided_exceeds_max_inputs
+    id = ["1", "2"]
+    assert_raises ::EncodedId::InvalidInputError do
+      ::EncodedId::ReversibleId.new(salt: salt, max_inputs_per_id: 1).encode(id)
+    end
+  end
+
+  def test_it_raises_when_encode_hex_amount_of_id_provided_exceeds_max_inputs
+    id = "9a566b8b-8618-42ab-8db7-a5a0276401fd"
+    assert_raises ::EncodedId::InvalidInputError do
+      ::EncodedId::ReversibleId.new(salt: salt, max_inputs_per_id: 1).encode_hex(id)
     end
   end
 

--- a/test/encoded_id/test_reversible_id.rb
+++ b/test/encoded_id/test_reversible_id.rb
@@ -420,9 +420,9 @@ class TestReversibleId < Minitest::Test
   end
 
   def test_it_raises_when_encode_hex_amount_of_id_provided_exceeds_max_inputs
-    id = ["9a566b8b-8618-42ab-8db7-a5a0276401fd", "9a566b8b-8618-42ab-8db7-a5a0276401fd"]
+    id = "9a566b8b-8618-42ab-8db7-a5a0276401fd"
     assert_raises ::EncodedId::InvalidInputError do
-      ::EncodedId::ReversibleId.new(salt: salt, max_inputs_per_id: 1).encode_hex(id)
+      ::EncodedId::ReversibleId.new(salt: salt, max_inputs_per_id: 7).encode_hex(id)
     end
   end
 


### PR DESCRIPTION
## Summary
- `max_inputs_per_id` to check length of array provided as input for `encode` and `encode_hex`
- set default `max_inputs_per_id` to 32

## Related issue

#5 

## Checklist:
- [x] Updated the documentation accordingly.
- [x] Added tests to cover changes.
- [x] All new and existing tests passed.

